### PR TITLE
Use pageSize to request 1000 items at once.

### DIFF
--- a/resources/lib/vtmgo.py
+++ b/resources/lib/vtmgo.py
@@ -198,9 +198,9 @@ class VtmGo:
 
     def get_items(self, category=None):
         if category:
-            response = self._get_url('/vtmgo/catalog?filter=' + category)
+            response = self._get_url('/vtmgo/catalog?pageSize=%d&filter=%s' % (1000, quote(category)))
         else:
-            response = self._get_url('/vtmgo/catalog')
+            response = self._get_url('/vtmgo/catalog?pageSize=%d' % 1000)
         info = json.loads(response)
 
         items = []


### PR DESCRIPTION
The vtm go app requests 20 items at once (it loads the next page when scrolling down). When the parameter is not specified, it returns 50 items. We can just increase the value to 1000 (or more). `0` or `-1` isn't accepted.

It can be possible to implement pagination, but I don't think we will have this issue with 1000 items.

Fixes #19 