### PR TITLE
Fix ordering.

### DIFF
--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -164,12 +164,10 @@ def show_catalog(category=None):
             listitem.setProperty('IsPlayable', 'true')
 
             if item.type == Content.CONTENT_TYPE_MOVIE:
-                xbmcplugin.addDirectoryItem(
-                    plugin.handle, plugin.url_for(play_movie, movie=item.id), listitem)
+                xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(play_movie, movie=item.id), listitem)
 
             elif item.type == Content.CONTENT_TYPE_PROGRAM:
-                xbmcplugin.addDirectoryItem(
-                    plugin.handle, plugin.url_for(show_program, program=item.id), listitem, True)
+                xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_program, program=item.id), listitem, True)
 
         if category == 'films':
             xbmcplugin.setContent(plugin.handle, 'movies')
@@ -243,8 +241,7 @@ def show_program(program, season=None):
                 'plot': '[B]%s[/B]\n%s' % (program_obj.name, program_obj.description),
                 'set': program_obj.name,
             })
-            xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_program, program=program, season='all'),
-                                        listitem, True)
+            xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_program, program=program, season='all'), listitem, True)
 
         for s in program_obj.seasons.values():
             listitem = ListItem('Season %d' % s.number, offscreen=True)
@@ -260,8 +257,7 @@ def show_program(program, season=None):
                 'set': program_obj.name,
                 'season': season,
             })
-            xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_program, program=program, season=s.number),
-                                        listitem, True)
+            xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_program, program=program, season=s.number), listitem, True)
         xbmcplugin.setContent(plugin.handle, 'tvshows')
 
         # Sort by label. Some programs return seasons unordered.
@@ -350,20 +346,19 @@ def show_search():
             listitem.setInfo('video', {
                 'mediatype': 'movie',
             })
-            xbmcplugin.addDirectoryItem(
-                plugin.handle, plugin.url_for(play_movie, movie=item.id), listitem)
+            xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(play_movie, movie=item.id), listitem)
 
         elif item.type == Content.CONTENT_TYPE_PROGRAM:
             listitem.setInfo('video', {
                 'mediatype': None,  # This shows a folder icon
             })
-            xbmcplugin.addDirectoryItem(
-                plugin.handle, plugin.url_for(show_program, program=item.id), listitem, True)
+            xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_program, program=item.id), listitem, True)
 
     xbmcplugin.setContent(plugin.handle, 'tvshows')
 
     # Sort like we get our results back.
     xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_UNSORTED)
+    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL_IGNORE_FOLDERS)
     xbmcplugin.endOfDirectory(plugin.handle)
 
 

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -363,7 +363,7 @@ def show_search():
     xbmcplugin.setContent(plugin.handle, 'tvshows')
 
     # Sort like we get our results back.
-    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL)
+    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_UNSORTED)
     xbmcplugin.endOfDirectory(plugin.handle)
 
 

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, unicode_literals
+
 import logging
 
 import xbmc
-from xbmcaddon import Addon
 import xbmcplugin
+from xbmcaddon import Addon
 from xbmcgui import Dialog, ListItem
-import routing
 
+import routing
 from resources.lib import kodilogging
 from resources.lib import kodiutils
 from resources.lib import vtmgostream
@@ -60,7 +61,6 @@ def index():
     xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_search), listitem, True)
 
     xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_UNSORTED)
-    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL)
     xbmcplugin.endOfDirectory(plugin.handle)
 
 
@@ -82,7 +82,10 @@ def show_live():
         description = ''
         try:
             if channel.epg[0]:
-                description = 'Now: ' + channel.epg[0].start.strftime('%H:%M') + ' - ' + channel.epg[0].end.strftime('%H:%M') + '\n'
+                description = 'Now: %s - %s\n' % (
+                    channel.epg[0].start.strftime('%H:%M'),
+                    channel.epg[0].end.strftime('%H:%M')
+                )
                 description += channel.epg[0].title + '\n'
                 description += '\n'
         except IndexError:
@@ -90,7 +93,10 @@ def show_live():
 
         try:
             if channel.epg[1]:
-                description += 'Next: ' + channel.epg[1].start.strftime('%H:%M') + ' - ' + channel.epg[1].end.strftime('%H:%M') + '\n'
+                description += 'Next: %s - %s\n' % (
+                    channel.epg[1].start.strftime('%H:%M'),
+                    channel.epg[1].end.strftime('%H:%M')
+                )
                 description += channel.epg[1].title + '\n'
                 description += '\n'
         except IndexError:
@@ -106,6 +112,7 @@ def show_live():
 
         xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(play_live, channel=channel.id) + '?.pvr', listitem)
 
+    # Sort live channels by default like in VTM GO.
     xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_UNSORTED)
     xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL)
     xbmcplugin.endOfDirectory(plugin.handle)
@@ -130,8 +137,9 @@ def show_catalog(category=None):
             })
             xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_catalog, category=cat.id), listitem, True)
 
-        xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL)
+        # Sort categories by default like in VTM GO.
         xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_UNSORTED)
+        xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL)
 
     else:
         # Show the items of a category
@@ -156,19 +164,21 @@ def show_catalog(category=None):
             listitem.setProperty('IsPlayable', 'true')
 
             if item.type == Content.CONTENT_TYPE_MOVIE:
-                # TODO: Doesn't seem to start the stream when I open it in an popup.
-                # xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_movie, movie=item.id), listitem)
-                xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(play_movie, movie=item.id), listitem)
+                xbmcplugin.addDirectoryItem(
+                    plugin.handle, plugin.url_for(play_movie, movie=item.id), listitem)
+
             elif item.type == Content.CONTENT_TYPE_PROGRAM:
-                xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_program, program=item.id), listitem, True)
+                xbmcplugin.addDirectoryItem(
+                    plugin.handle, plugin.url_for(show_program, program=item.id), listitem, True)
 
         if category == 'films':
             xbmcplugin.setContent(plugin.handle, 'movies')
         else:
             xbmcplugin.setContent(plugin.handle, 'tvshows')
 
-        xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_UNSORTED)
-        xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL)
+        # Sort items by label, but don't put folders at the top.
+        # Used for A-Z listing or when movies and episodes are mixed.
+        xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL_IGNORE_FOLDERS)
 
     xbmcplugin.endOfDirectory(plugin.handle)
 
@@ -233,7 +243,8 @@ def show_program(program, season=None):
                 'plot': '[B]%s[/B]\n%s' % (program_obj.name, program_obj.description),
                 'set': program_obj.name,
             })
-            xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_program, program=program, season='all'), listitem, True)
+            xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_program, program=program, season='all'),
+                                        listitem, True)
 
         for s in program_obj.seasons.values():
             listitem = ListItem('Season %d' % s.number, offscreen=True)
@@ -249,11 +260,12 @@ def show_program(program, season=None):
                 'set': program_obj.name,
                 'season': season,
             })
-            xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_program, program=program, season=s.number), listitem, True)
+            xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_program, program=program, season=s.number),
+                                        listitem, True)
         xbmcplugin.setContent(plugin.handle, 'tvshows')
-        xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_EPISODE)
+
+        # Sort by label. Some programs return seasons unordered.
         xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL)
-        xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_UNSORTED)  # If you use unsorted, seasons go like: 8, 1, 9, 7
         xbmcplugin.endOfDirectory(plugin.handle)
         return
 
@@ -287,12 +299,9 @@ def show_program(program, season=None):
             xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(play_episode, episode=episode.id), listitem)
 
     xbmcplugin.setContent(plugin.handle, 'episodes')
-    if season == 'all':  # If we sort episodes of all seasons, sorting by episode sorts also by season
-        xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_EPISODE)
-        xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_UNSORTED)
-    else:
-        xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_UNSORTED)
-        xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_EPISODE)
+
+    # Sort by episode number by default. Takes seasons into account.
+    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_EPISODE)
     xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL)
     xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_DURATION)
     xbmcplugin.endOfDirectory(plugin.handle)
@@ -309,6 +318,8 @@ def show_youtube():
             'mediatype': 'video',
         })
         xbmcplugin.addDirectoryItem(plugin.handle, entry.get('path'), listitem, True)
+
+    # Sort by default like in our dict.
     xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_UNSORTED)
     xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL)
     xbmcplugin.endOfDirectory(plugin.handle)
@@ -334,19 +345,24 @@ def show_search():
     # Display results
     for item in items:
         listitem = ListItem(item.title, offscreen=True)
-        listitem.setInfo('video', {
-            'mediatype': 'tvshow',
-        })
 
         if item.type == Content.CONTENT_TYPE_MOVIE:
-            # TODO: Doesn't seem to start the stream when I open it in an popup.
-            # xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_movie, movie=item.id), listitem)
-            xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(play_movie, movie=item.id), listitem)
+            listitem.setInfo('video', {
+                'mediatype': 'movie',
+            })
+            xbmcplugin.addDirectoryItem(
+                plugin.handle, plugin.url_for(play_movie, movie=item.id), listitem)
+
         elif item.type == Content.CONTENT_TYPE_PROGRAM:
-            xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_program, program=item.id), listitem, True)
+            listitem.setInfo('video', {
+                'mediatype': None,  # This shows a folder icon
+            })
+            xbmcplugin.addDirectoryItem(
+                plugin.handle, plugin.url_for(show_program, program=item.id), listitem, True)
 
     xbmcplugin.setContent(plugin.handle, 'tvshows')
-    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_UNSORTED)
+
+    # Sort like we get our results back.
     xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL)
     xbmcplugin.endOfDirectory(plugin.handle)
 

--- a/resources/lib/vtmgo.py
+++ b/resources/lib/vtmgo.py
@@ -220,8 +220,6 @@ class VtmGo:
                 video_type=item['target']['type'],
             ))
 
-        # Ensure unsorted view shows movies and programs alphabetically
-        items = sorted(items, key=lambda k: k.title)
         return items
 
     def get_movie(self, movie_id):


### PR DESCRIPTION
Fixes ordering trough the addon. Fixes #23.

* Used `SORT_METHOD_LABEL_IGNORE_FOLDERS` for items in a category or a-z. This causes the folders to included in the sorting.
* Switched to `SORT_METHOD_EPISODE` for all episode views.
* Removed `SORT_METHOD_UNSORTED` when it didn't make any sense.
* Added comments around every sort method to remember why it's sorted that way.
* Fixes movie/episode difference in search.

@dagwieers what do you think? 