### PR TITLE
Add proxy support

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -3,6 +3,7 @@
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
+        <import addon="script.module.pysocks" version="1.6.8" optional="true"/>
         <import addon="script.module.requests"/>
         <import addon="script.module.routing" version="0.2.0"/>
     </requires>

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -6,15 +6,21 @@ import logging
 
 import xbmc
 from xbmcaddon import Addon
-import xbmcgui
+from xbmcgui import Dialog
 
 # read settings
 ADDON = Addon()
 logger = logging.getLogger(__name__)
 
 
-def notification(header, message, time=5000, icon=ADDON.getAddonInfo('icon'), sound=True):
-    xbmcgui.Dialog().notification(header, message, icon, time, sound)
+def notification(heading=ADDON.getAddonInfo('name'), message='', time=5000, icon=ADDON.getAddonInfo('icon'), sound=True):
+    ''' Show a Kodi notification '''
+    Dialog().notification(heading=heading, message=message, icon=icon, time=time, sound=sound)
+
+
+def show_ok_dialog(heading=ADDON.getAddonInfo('name'), message=''):
+    ''' Show Kodi's OK dialog '''
+    Dialog().ok(heading=heading, line1=message)
 
 
 def show_settings():
@@ -72,4 +78,63 @@ def kodi_json_request(params):
 def get_global_setting(setting):
     ''' Get a Kodi setting '''
     json_result = xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Settings.GetSettingValue", "params": {"setting": "%s"}, "id": 1}' % setting)
-    return json.loads(json_result).get('result', dict()).get('value')
+    # TODO: Implement proper kodi stubs for testing
+    try:
+        return json.loads(json_result).get('result', dict()).get('value')
+    except ValueError:  # e.g. when xbmc.executeJSONRPC is a stub
+        return None
+
+
+def has_socks():
+    ''' Test if socks is installed, and remember this information '''
+    if not hasattr(has_socks, 'installed'):
+        try:
+            import socks  # noqa: F401; pylint: disable=unused-variable,unused-import
+            has_socks.installed = True
+        except ImportError:
+            has_socks.installed = False
+            return None  # Detect if this is the first run
+    return has_socks.installed
+
+
+def get_proxies():
+    ''' Return a usable proxies dictionary from Kodi proxy settings '''
+    usehttpproxy = get_global_setting('network.usehttpproxy')
+    if usehttpproxy is False:
+        return None
+
+    httpproxytype = get_global_setting('network.httpproxytype')
+
+    socks_supported = has_socks()
+    if httpproxytype != 0 and not socks_supported:
+        # Only open the dialog the first time (to avoid multiple popups)
+        if socks_supported is None:
+            show_ok_dialog('', 'Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed.')
+        return None
+
+    proxy_types = ['http', 'socks4', 'socks4a', 'socks5', 'socks5h']
+    if 0 <= httpproxytype < 5:
+        httpproxyscheme = proxy_types[httpproxytype]
+    else:
+        httpproxyscheme = 'http'
+
+    httpproxyserver = get_global_setting('network.httpproxyserver')
+    httpproxyport = get_global_setting('network.httpproxyport')
+    httpproxyusername = get_global_setting('network.httpproxyusername')
+    httpproxypassword = get_global_setting('network.httpproxypassword')
+
+    if httpproxyserver and httpproxyport and httpproxyusername and httpproxypassword:
+        proxy_address = '%s://%s:%s@%s:%s' % (httpproxyscheme, httpproxyusername, httpproxypassword, httpproxyserver, httpproxyport)
+    elif httpproxyserver and httpproxyport and httpproxyusername:
+        proxy_address = '%s://%s@%s:%s' % (httpproxyscheme, httpproxyusername, httpproxyserver, httpproxyport)
+    elif httpproxyserver and httpproxyport:
+        proxy_address = '%s://%s:%s' % (httpproxyscheme, httpproxyserver, httpproxyport)
+    elif httpproxyserver:
+        proxy_address = '%s://%s' % (httpproxyscheme, httpproxyserver)
+    else:
+        return None
+
+    return dict(http=proxy_address, https=proxy_address)
+
+
+proxies = get_proxies()

--- a/resources/lib/vtmgo.py
+++ b/resources/lib/vtmgo.py
@@ -8,6 +8,7 @@ from urllib import quote
 import dateutil.parser
 import requests
 from xbmcaddon import Addon
+from resources.lib.kodiutils import proxies
 
 ADDON = Addon()
 logger = logging.getLogger(ADDON.getAddonInfo('id'))
@@ -301,7 +302,7 @@ class VtmGo:
         if auth:
             headers['x-dpp-jwt'] = auth
 
-        response = requests.session().get('https://api.vtmgo.be' + url, headers=headers, verify=False)
+        response = requests.session().get('https://api.vtmgo.be' + url, headers=headers, verify=False, proxies=proxies)
 
         if response.status_code != 200:
             raise Exception('Error %s.' % response.status_code)

--- a/resources/lib/vtmgoauth.py
+++ b/resources/lib/vtmgoauth.py
@@ -10,6 +10,7 @@ import re
 import requests
 from requests.exceptions import InvalidSchema
 from xbmcaddon import Addon
+from resources.lib.kodiutils import proxies
 
 ADDON = Addon()
 logger = logging.getLogger(ADDON.getAddonInfo('id'))
@@ -38,7 +39,7 @@ class VtmGoAuth:
             'scope': 'openid profile'
         }, headers={
             'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36'
-        })
+        }, proxies=proxies)
 
         # Now, send the login details. We will be redirected to vtmgo:// when we succeed. We then can extract an authorizationCode that we need to continue.
         try:

--- a/resources/lib/vtmgostream.py
+++ b/resources/lib/vtmgostream.py
@@ -10,6 +10,7 @@ from urllib import urlencode, quote
 
 import requests
 from xbmcaddon import Addon
+from resources.lib.kodiutils import proxies
 
 ADDON = Addon()
 logger = logging.getLogger(ADDON.getAddonInfo('id'))
@@ -118,7 +119,8 @@ class VtmGoStream:
                                          'x-api-key': self._VTM_API_KEY,
                                          'Popcorn-SDK-Version': '1',
                                          'User-Agent': 'Dalvik/2.1.0 (Linux; U; Android 6.0.1; Nexus 5 Build/M4B30Z)',
-                                     })
+                                     },
+                                     proxies=proxies)
 
         if response.status_code != 200:
             raise Exception('Error %s in _get_stream_info.' % response.status_code)


### PR DESCRIPTION
This adds Kodi proxy support by providing the Kodi proxy settings to the Requests library. It supports both SOCKS and HTTP proxies (just like Kodi settings supports).

SOCKS support requires PySocks, an external library, on Windows.

This fixes #26