### PR TITLE
add inputstreamhelper to auto install Widevine CDM

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -6,6 +6,7 @@
         <import addon="script.module.pysocks" version="1.6.8" optional="true"/>
         <import addon="script.module.requests"/>
         <import addon="script.module.routing" version="0.2.0"/>
+        <import addon="script.module.inputstreamhelper" version="0.3.4"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="main.py">
         <provides>video</provides>

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -417,20 +417,28 @@ def _stream(strtype, strid):
 
     listitem.setProperty('IsPlayable', 'true')
     listitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
-    listitem.setProperty('inputstream.adaptive.license_type', 'com.widevine.alpha')
     listitem.setProperty('inputstream.adaptive.manifest_type', 'mpd')
-    listitem.setProperty('inputstream.adaptive.license_key',
-                         _vtmgostream.create_license_key(resolved_stream.license_url, key_headers={
-                             'User-Agent': 'ANVSDK Android/5.0.39 (Linux; Android 6.0.1; Nexus 5)',
-                         }))
-
-    if strtype == 'channels':
-        listitem.setProperty('inputstream.adaptive.manifest_update_parameter', 'full')
-
     listitem.setMimeType('application/dash+xml')
     listitem.setContentLookup(False)
 
-    xbmcplugin.setResolvedUrl(plugin.handle, True, listitem)
+    if strtype == 'channels':
+        listitem.setProperty('inputstream.adaptive.manifest_update_parameter', 'full')
+    try:
+        from inputstreamhelper import Helper
+    except ImportError:
+        Dialog().ok(heading='VTM GO Add-on', line1='Please reboot Kodi')
+        return
+    is_helper = Helper('mpd', drm='com.widevine.alpha')
+    if is_helper.check_inputstream():
+        listitem.setProperty('inputstream.adaptive.license_type', 'com.widevine.alpha')
+        listitem.setProperty('inputstream.adaptive.license_key',
+                             _vtmgostream.create_license_key(resolved_stream.license_url, key_headers={
+                                 'User-Agent': 'ANVSDK Android/5.0.39 (Linux; Android 6.0.1; Nexus 5)',
+                             }))
+
+        xbmcplugin.setResolvedUrl(plugin.handle, True, listitem)
+    else:
+        Dialog().ok(heading='VTM GO Add-on', line1='You need to install InputStream Adaptive and Widevine CDM in Kodi to play this stream')
 
 
 def run(params):


### PR DESCRIPTION
Currently, nothing happens when a user selects a playable item and Widevine CDM is missing on the Kodi installation. This pull request fixes this.