### PR TITLE
Assorted fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,10 @@ addon_xml = addon.xml
 # Collect information to build as sensible package name
 name = $(shell xmllint --xpath 'string(/addon/@id)' $(addon_xml))
 version = $(shell xmllint --xpath 'string(/addon/@version)' $(addon_xml))
+git_branch = $(shell git rev-parse --abbrev-ref HEAD)
 git_hash = $(shell git rev-parse --short HEAD)
 
-zip_name = $(name)-$(version)-$(git_hash).zip
+zip_name = $(name)-$(version)-$(git_branch)-$(git_hash).zip
 include_files = main.py addon.xml LICENSE README.md resources/
 include_paths = $(patsubst %,$(name)/%,$(include_files))
 exclude_files = \*.new \*.orig \*.pyc \*.pyo

--- a/addon.xml
+++ b/addon.xml
@@ -2,6 +2,8 @@
 <addon id="plugin.video.vtm.go" name="VTM GO" version="0.1" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
+        <!-- import addon="resource.images.studios.coloured" version="0.0.18" optional="true"/ -->
+        <!-- import addon="resource.images.studios.white" version="0.0.22" optional="true"/ -->
         <import addon="script.module.dateutil" version="2.6.0"/>
         <import addon="script.module.pysocks" version="1.6.8" optional="true"/>
         <import addon="script.module.requests"/>

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -85,6 +85,11 @@ def get_global_setting(setting):
         return None
 
 
+def get_cond_visibility(condition):
+    ''' Test a condition in XBMC '''
+    return xbmc.getCondVisibility(condition)
+
+
 def has_socks():
     ''' Test if socks is installed, and remember this information '''
     if not hasattr(has_socks, 'installed'):


### PR DESCRIPTION
This PR includes:
- Support for studio icons (optional)
- Add get_cond_visibility() support
- Renamed /live to /livetv
- Rewrote plot formatting for programs, episodes, movies and livetv
- Added studio support
- Improved geo-blocked support (most, if not all, are not geo-blocked)
- Use dict get() to avoid potential KeyError
- Strip episode number from name
- Add branch name to ZIP file

This fixes #39