### PR TITLE
Set correct API version since we depend on Leia

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.vtm.go" name="VTM GO" version="0.1" provider-name="Michaël Arnauts">
     <requires>
-        <import addon="xbmc.python" version="2.25.0"/>
+        <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
         <import addon="script.module.pysocks" version="1.6.8" optional="true"/>
-        <import addon="script.module.requests"/>
+        <import addon="script.module.requests" version="2.22.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
         <import addon="script.module.inputstreamhelper" version="0.3.4"/>
     </requires>


### PR DESCRIPTION
We need to depend on xbmc.python 2.26.0 to depend on Leia.
See https://kodi.wiki/view/Addon.xml#Dependency_versions