### PR TITLE
Move to Kids Zone

### DIFF
--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -22,8 +22,8 @@ plugin = routing.Plugin()
 
 
 @plugin.route('/')
-def index():
-    kids = get_setting_as_bool('kids_mode_enabled')
+def show_index():
+    kids = _get_kids_mode()
 
     listitem = ListItem('A-Z', offscreen=True)
     listitem.setArt({'icon': 'DefaultMovieTitle.png'})
@@ -62,30 +62,16 @@ def index():
     })
     xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_search, kids=kids), listitem, True)
 
-    if get_setting_as_bool('kids_mode_switching'):
-        if not kids:
-            listitem = ListItem('Enable Kids Mode', offscreen=True)
-            listitem.setArt({'icon': 'DefaultUser.png'})
-            listitem.setInfo('video', {
-                'plot': 'Enable the Kids Mode',
-            })
-            xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(kids_mode, status='enable'), listitem, True)
-        else:
-            listitem = ListItem('Disable Kids Mode', offscreen=True)
-            listitem.setArt({'icon': 'DefaultUser.png'})
-            listitem.setInfo('video', {
-                'plot': 'Disable the Kids Mode',
-            })
-            xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(kids_mode, status='disable'), listitem, True)
+    if get_setting_as_bool('kids_mode_switching') and not kids:
+        listitem = ListItem('Kids Zone', offscreen=True)
+        listitem.setArt({'icon': 'DefaultUser.png'})
+        listitem.setInfo('video', {
+            'plot': 'Go to the Kids Zone',
+        })
+        xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_index, kids=True), listitem, True)
 
     xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_UNSORTED)
     xbmcplugin.endOfDirectory(plugin.handle)
-
-
-@plugin.route('/kids-mode/<status>')
-def kids_mode(status):
-    set_setting('kids_mode_enabled', 'true' if status == 'enable' else 'false')
-    xbmc.executebuiltin('Container.Refresh')
 
 
 @plugin.route('/check-credentials')
@@ -549,6 +535,10 @@ def _stream(strtype, strid):
 
 
 def _get_kids_mode():
+
+    if get_setting_as_bool('kids_zone_forced'):
+        return True
+
     # kids will contain a string of 'True' or 'False'
     kids = plugin.args.get('kids')
     if kids:

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -20,6 +20,8 @@ logger = logging.getLogger(ADDON.getAddonInfo('id'))
 kodilogging.config()
 plugin = routing.Plugin()
 
+KIDS_MODE_STR = '\n\n[B][COLOR lightblue]Kids Zone[/COLOR][/B]'
+
 
 @plugin.route('/')
 def show_index():
@@ -28,21 +30,24 @@ def show_index():
     listitem = ListItem('A-Z', offscreen=True)
     listitem.setArt({'icon': 'DefaultMovieTitle.png'})
     listitem.setInfo('video', {
-        'plot': 'Alphabetically sorted list of programs',
+        'plot': 'Alphabetically sorted list of programs' +
+                (KIDS_MODE_STR if kids else ''),
     })
     xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_catalog, category='all', kids=kids), listitem, True)
 
     listitem = ListItem('Catalogue', offscreen=True)
     listitem.setArt({'icon': 'DefaultGenre.png'})
     listitem.setInfo('video', {
-        'plot': 'TV Shows and Movies listed by category',
+        'plot': 'TV Shows and Movies listed by category' +
+                (KIDS_MODE_STR if kids else ''),
     })
     xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_catalog, kids=kids), listitem, True)
 
     listitem = ListItem('Live TV', offscreen=True)
     listitem.setArt({'icon': 'DefaultAddonPVRClient.png'})
     listitem.setInfo('video', {
-        'plot': 'Watch channels live via Internet',
+        'plot': 'Watch channels live via Internet' +
+                (KIDS_MODE_STR if kids else ''),
     })
     xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_livetv, kids=kids), listitem, True)
 
@@ -51,14 +56,16 @@ def show_index():
         listitem = ListItem('YouTube', offscreen=True)
         listitem.setArt({'icon': 'DefaultTags.png'})
         listitem.setInfo('video', {
-            'plot': 'Watch YouTube content',
+            'plot': 'Watch YouTube content' +
+                    (KIDS_MODE_STR if kids else ''),
         })
         xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_youtube, kids=kids), listitem, True)
 
     listitem = ListItem('Search', offscreen=True)
     listitem.setArt({'icon': 'DefaultAddonsSearch.png'})
     listitem.setInfo('video', {
-        'plot': 'Search the VTM GO catalogue',
+        'plot': 'Search the VTM GO catalogue' +
+                (KIDS_MODE_STR if kids else ''),
     })
     xbmcplugin.addDirectoryItem(plugin.handle, plugin.url_for(show_search, kids=kids), listitem, True)
 

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -12,7 +12,7 @@ from xbmcgui import Dialog, ListItem
 import routing
 from resources.lib import kodilogging
 from resources.lib import vtmgostream
-from resources.lib.kodiutils import get_cond_visibility, get_global_setting, get_setting, notification, show_ok_dialog, show_settings, get_setting_as_bool, set_setting
+from resources.lib.kodiutils import get_cond_visibility, get_global_setting, get_setting, notification, show_ok_dialog, show_settings, get_setting_as_bool
 from resources.lib.vtmgo import VtmGo, Content
 
 ADDON = Addon()
@@ -535,7 +535,6 @@ def _stream(strtype, strid):
 
 
 def _get_kids_mode():
-
     if get_setting_as_bool('kids_zone_forced'):
         return True
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,8 +5,7 @@
         <setting id="password" option="hidden" type="text" label="Password" default=""/>
         <setting subsetting="true" label="Check your credentials" type="action" option="close" action="RunPlugin(plugin://plugin.video.vtm.go/check-credentials)" enable="!eq(-2,) + !eq(-1,)"/>
     </category>
-    <category label="Kids Mode">
-        <setting id="kids_mode_switching" type="bool" label="Allow Kids Mode switching" default="true"/>
-        <setting id="kids_mode_enabled" type="bool" label="Enable Kids Mode" default="false"/>
+    <category label="Kids Zone">
+        <setting id="kids_zone_forced" type="bool" label="Force Kids Zone" default="false"/>
     </category>
 </settings>


### PR DESCRIPTION
Follow up on #44 

Move to a "Kids Zone" item in the root directory to go to the kids catalog. A setting is used to enforce the plugin to go to this mode by default.

I still would like a way to see more clearly that you are in the kids zone, since the menu looks identical.

I'm still not sure if this is the way I like this, I need to do some more testing.