### PR TITLE
Add description during playback

### DIFF
--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -505,6 +505,17 @@ def _stream(strtype, strid):
     if resolved_stream is None:  # If no stream is available (i.e. geo-blocked)
         return
 
+    # Lookup metadata
+    _vtmgo = VtmGo()
+    if strtype == 'movies':
+        details = _vtmgo.get_movie(strid)
+        description = details.description
+    elif strtype == 'episodes':
+        details = _vtmgo.get_episode(strid)
+        description = details.description
+    else:
+        description = None
+
     # Create listitem
     listitem = ListItem(path=resolved_stream.url, offscreen=True)
 
@@ -512,6 +523,7 @@ def _stream(strtype, strid):
     listitem.setInfo('video', {
         'title': resolved_stream.title,
         'tvshowtitle': resolved_stream.program,
+        'plot': description,
         'duration': resolved_stream.duration,
     })
     listitem.addStreamInfo('video', {

--- a/resources/lib/vtmgo.py
+++ b/resources/lib/vtmgo.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, unicode_literals
-import re
-import os.path
+
 import json
 import logging
+import os.path
+import re
+
 try:  # Python 3
     from urllib.parse import quote
 except ImportError:  # Python 2
@@ -323,11 +325,19 @@ class VtmGo:
             legal=program.get('legalIcons'),
         )
 
-    # def get_episodes(self, episode_id):
-    #     response = self._get_url('/%s/episodes/%s' % (self._mode, episode_id))
-    #     info = json.loads(response)
-    #
-    #     return info
+    def get_episode(self, episode_id):
+        response = self._get_url('/%s/episodes/%s' % (self._mode, episode_id))
+        info = json.loads(response)
+        episode = info.get('episode', {})
+
+        return Episode(
+            episode_id=episode.get('id'),
+            number=episode.get('index'),
+            season=episode.get('seasonIndex'),
+            name=episode.get('name'),
+            description=episode.get('description'),
+            cover=episode.get('bigPhotoUrl'),
+        )
 
     def do_search(self, search):
         response = self._get_url('/%s/autocomplete/?maxItems=50&keywords=%s' % (self._mode, quote(search)))

--- a/test/vtmgo.py
+++ b/test/vtmgo.py
@@ -82,10 +82,10 @@ class TestVtmGo(unittest.TestCase):
         self.assertTrue(info)
         print(info)
 
-    # def test_get_episodes(self):
-    #     info = self._vtmgo.get_episodes('ae0fa98d-6ed5-4f4a-8581-a051ed3bb755')
-    #     self.assertTrue(info)
-    #     print(info)
+    def test_get_episode(self):
+        info = self._vtmgo.get_episode('ae0fa98d-6ed5-4f4a-8581-a051ed3bb755')
+        self.assertTrue(info)
+        print(info)
 
     def test_get_stream(self):
         info = self._vtmgostream.get_stream('episodes', 'ae0fa98d-6ed5-4f4a-8581-a051ed3bb755')


### PR DESCRIPTION
When playing a movie or episode, the description wasn't filled in during the playback. You see this when pausing the stream.

We now fetch this before starting the stream so we can fill in the description. Not all fields are available compared to the `get_items` call.