### PR TITLE
delay subtitles taking into account advertisements breaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,4 @@ clean:
 	find . -name '__pycache__' -type d -delete
 	rm -rf .pytest_cache/ .tox/
 	rm -f *.log
+	rm -rf test/userdata/temp

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, unicode_literals
 import xbmc
 from xbmcaddon import Addon
 from xbmcgui import Dialog
+from xbmcvfs import delete, exists, File, listdir, mkdir, rmdir
 
 ADDON = Addon()
 
@@ -98,6 +99,41 @@ def get_max_bandwidth():
     if global_max_bandwidth != 0:
         return global_max_bandwidth
     return 0
+
+
+def get_profile_path():
+    ''' Get profile path '''
+    return xbmc.translatePath(ADDON.getAddonInfo('profile'))
+
+
+def path_exists(path):
+    ''' Check if the path exists (using xbmcvfs) '''
+    return exists(path)
+
+
+def list_dir(path):
+    ''' Lists content of a directory (using xbmcvfs) '''
+    return listdir(path)
+
+
+def make_dir(path):
+    ''' Make a directory (using xbmcvfs) '''
+    return mkdir(path)
+
+
+def remove_dir(path):
+    ''' Remove a directory (using xbmcvfs) '''
+    return rmdir(path)
+
+
+def delete_file(path):
+    ''' Delete a file (using xbmcvfs) '''
+    return delete(path)
+
+
+def open_file(path, mode=None):
+    ''' Open a file (using xbmcvfs) '''
+    return File(path, mode)
 
 
 def get_proxies():

--- a/test/test_vtmgo.py
+++ b/test/test_vtmgo.py
@@ -101,6 +101,12 @@ class TestVtmGo(unittest.TestCase):
         epg = self._vtmgoepg.get_epg()
         print(epg)
 
+    def test_get_stream_with_subtitles(self):
+        # 13 Geboden - Episode 2
+        info = self._vtmgostream.get_stream('episodes', '2fafb247-0368-46d4-bdcf-fb209420e715')
+        self.assertTrue(info)
+        print(info)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/xbmcextra.py
+++ b/test/xbmcextra.py
@@ -39,8 +39,8 @@ def uri_to_path(uri):
 def read_addon_xml(path):
     ''' Parse the addon.xml and return an info dictionary '''
     info = dict(
-        path='./',  # '/storage/.kodi/addons/plugin.video.vtm.go',
-        profile='special://userdata',  # 'special://profile/addon_data/plugin.video.vtm.go/',
+        path='./',   # '/storage/.kodi/addons/plugin.video.vtm.go',
+        profile=os.path.join(os.getcwd(), 'test/userdata/'),  # 'special://profile/addon_data/plugin.video.vtm.go/',
         type='xbmc.python.pluginsource',
     )
 

--- a/test/xbmcvfs.py
+++ b/test/xbmcvfs.py
@@ -62,3 +62,8 @@ def mkdir(path):
 def mkdirs(path):
     ''' A reimplementation of the xbmcvfs mkdirs() function '''
     return os.makedirs(path)
+
+
+def rmdir(path):
+    ''' A reimplementation of the xbmcvfs rmdir() function '''
+    return os.rmdir(path)


### PR DESCRIPTION
This is a very experimental fix for https://github.com/michaelarnauts/plugin.video.vtm.go/issues/51
It works as follows:
1. get advertisement breaks start timestamps and durations from manifest json file
2. load external WEBVTT subtitle file into memory
3. delay subtitle timestamps with ad break duration if advertisement break starts before the subtitle starts
4. save edited WEBVTT file with delayed timestamps to addon profile folder
5. add local WEBVTT path to subtitle_info in ResolvedStream object