### PR TITLE
Implement TV Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The following features are supported:
 * Watch live TV (VTM, Q2, Vitaya, CAZ, VTM Kids, VTM Kids Jr & QMusic)
 * Watch on-demand content (movies and series)
 * Watch YouTube content from some of the Medialaan channels
+* Browse a TV Guide
 * Search the catalogue
 * Browse the Kids zone
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -46,7 +46,7 @@ msgid "YouTube"
 msgstr ""
 
 msgctxt "#30008"
-msgid "Watch YouTube content'"
+msgid "Watch YouTube content"
 msgstr ""
 
 msgctxt "#30009"
@@ -65,6 +65,13 @@ msgctxt "#30012"
 msgid "Go to the Kids Zone"
 msgstr ""
 
+msgctxt "#30013"
+msgid "TV Guide"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Browse the TV Guide"
+msgstr ""
 
 ### CODE
 msgctxt "#30200"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -46,7 +46,7 @@ msgid "YouTube"
 msgstr ""
 
 msgctxt "#30008"
-msgid "Watch YouTube content'"
+msgid "Watch YouTube content"
 msgstr ""
 
 msgctxt "#30009"
@@ -65,6 +65,13 @@ msgctxt "#30012"
 msgid "Go to the Kids Zone"
 msgstr ""
 
+msgctxt "#30013"
+msgid "TV Guide"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Browse the TV Guide"
+msgstr ""
 
 ### CODE
 msgctxt "#30200"

--- a/resources/lib/__init__.py
+++ b/resources/lib/__init__.py
@@ -55,3 +55,48 @@ YOUTUBE = [
         kids=False,
     ),
 ]
+
+CHANNELS = [
+    dict(
+        label='VTM',
+        studio='VTM',
+        key='vtm',
+        kids=False,
+    ),
+    dict(
+        label='Q2',
+        studio='Q2',
+        key='q2',
+        kids=False,
+    ),
+    dict(
+        label='Vitaya',
+        studio='Vitaya',
+        key='vitaya',
+        kids=False,
+    ),
+    dict(
+        label='CAZ',
+        studio='CAZ',
+        key='caz',
+        kids=False,
+    ),
+    dict(
+        label='VTM KIDS',
+        studio='VTM KIDS',
+        key='vtm-kids',
+        kids=True,
+    ),
+    dict(
+        label='VTM KIDS Jr',
+        studio='VTM KIDS Jr',
+        key='vtm-kids-jr',
+        kids=True,
+    ),
+    dict(
+        label='QMusic',
+        studio='QMusic',
+        key='qmusic',
+        kids=False,
+    ),
+]

--- a/resources/lib/vtmgoepg.py
+++ b/resources/lib/vtmgoepg.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals
+
+import json
+from datetime import datetime, timedelta
+
+import dateutil.parser
+import requests
+
+
+class EpgChannel:
+    def __init__(self, uuid=None, key=None, name=None, logo=None, broadcasts=None):
+        self.uuid = uuid
+        self.key = key
+        self.name = name
+        self.logo = logo
+        self.broadcasts = broadcasts
+
+
+class EpgBroadcast:
+    def __init__(self, uuid=None, mediatype=None, title=None, time=None, duration=None, image=None, description=None, live=None, rerun=None, tip=None):
+        self.uuid = uuid
+        self.mediatype = mediatype
+        self.title = title
+        self.time = time
+        self.duration = duration
+        self.image = image
+        self.description = description
+        self.live = live
+        self.rerun = rerun
+        self.tip = tip
+
+    def __repr__(self):
+        return "%r" % self.__dict__
+
+
+class VtmGoEpg:
+    EPG_URL = 'https://vtm.be/tv-gids/api/v2/broadcasts/{date}'
+
+    def __init__(self):
+        self._session = requests.session()
+
+    def get_epg(self, date=None):
+        # TODO: implement caching
+
+        if date is None:
+            date = datetime.today().strftime('%Y-%m-%d')
+
+        response = self._session.get(self.EPG_URL.format(date=date))
+        if response.status_code != 200:
+            raise Exception('Error %s in _get_epg when fetching %s.' % (response.status_code, self.EPG_URL.format(date=date)))
+
+        epg = json.loads(response.text)
+
+        result = {}
+        for channel in epg.get('channels', []):
+            broadcasts = [self._parse_broadcast(broadcast) for broadcast in channel.get('broadcasts', [])]
+            result[channel.get('seoKey')] = EpgChannel(
+                name=channel.get('name'),
+                key=channel.get('seoKey'),
+                logo=channel.get('channelLogoUrl'),
+                broadcasts=broadcasts
+            )
+
+        return result
+
+    @staticmethod
+    def _parse_broadcast(broadcast_json):
+
+        # Sometimes, the duration field is empty, but luckily, we can calculate it.
+        duration = broadcast_json.get('duration')
+        if duration is None:
+            duration = (broadcast_json.get('to') - broadcast_json.get('from')) / 1000
+
+        return EpgBroadcast(
+            uuid=broadcast_json.get('uuid'),
+            mediatype=broadcast_json.get('playableType'),
+            title=broadcast_json.get('title'),
+            time=dateutil.parser.parse(broadcast_json.get('fromIso')),
+            duration=duration,
+            image=broadcast_json.get('imageUrl'),
+            description=broadcast_json.get('synopsis'),
+            live=broadcast_json.get('live'),
+            rerun=broadcast_json.get('rerun'),
+            tip=broadcast_json.get('tip'),
+        )
+
+    @staticmethod
+    def get_dates():
+        dates = []
+
+        today = datetime.today()
+
+        # The API provides 2 days in the past and 7 days in the future
+        for i in range(-2, 7):
+            day = today + timedelta(days=i)
+
+            # TODO: make this pretty
+            if i == -1:
+                title = 'Yesterday'
+            elif i == 0:
+                title = 'Today'
+            elif i == 1:
+                title = 'Tomorrow'
+            else:
+                title = day.strftime('%Y-%m-%d')
+
+            dates.append({
+                'title': title,
+                'date': day.strftime('%Y-%m-%d'),
+            })
+
+        return dates

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -68,6 +68,17 @@ class TestRouter(unittest.TestCase):
         plugin.run(['plugin://plugin.video.vtm.go/search', '0', ''])
         self.assertEqual(addon.url_for(plugin.show_search), 'plugin://plugin.video.vtm.go/search')
 
+    # TV Guide menu: '/tvguide'
+    def test_tvguide_menu(self):
+        plugin.run(['plugin://plugin.video.vtm.go/tvguide', '0', ''])
+        self.assertEqual(addon.url_for(plugin.show_tvguide), 'plugin://plugin.video.vtm.go/tvguide')
+
+        plugin.run(['plugin://plugin.video.vtm.go/tvguide/vtm', '0', ''])
+        self.assertEqual(addon.url_for(plugin.show_tvguide, channel='vtm'), 'plugin://plugin.video.vtm.go/tvguide/vtm')
+
+        # plugin.run(['plugin://plugin.video.vtm.go/tvguide/vtm/2019-01-01', '0', ''])
+        self.assertEqual(addon.url_for(plugin.show_tvguide_detail, channel='vtm', date='2019-01-01'), 'plugin://plugin.video.vtm.go/tvguide/vtm/2019-01-01')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_vtmgo.py
+++ b/test/test_vtmgo.py
@@ -10,7 +10,7 @@ import unittest
 
 from xbmcaddon import Addon
 
-from resources.lib import kodilogging, vtmgo, vtmgoauth, vtmgostream
+from resources.lib import kodilogging, vtmgo, vtmgoepg, vtmgoauth, vtmgostream
 
 ADDON = Addon()
 kodilogging.config()
@@ -24,6 +24,7 @@ class TestVtmGo(unittest.TestCase):
 
         self._token = None
         self._vtmgo = vtmgo.VtmGo()
+        self._vtmgoepg = vtmgoepg.VtmGoEpg()
 
         try:
             with open('test/credentials.json') as f:
@@ -98,6 +99,10 @@ class TestVtmGo(unittest.TestCase):
         info = self._vtmgostream.get_stream('channels', 'd8659669-b964-414c-aa9c-e31d8d15696b')
         self.assertTrue(info)
         print(info)
+
+    def test_get_epg(self):
+        epg = self._vtmgoepg.get_epg()
+        print(epg)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a basic EPG to the addon. It uses the api of vtm.be.

It currently is lacking a way to play something directly from the EPG since I don't have an id that I can use to start the stream. I need to look further into this.

Fixes #37 
