### PR TITLE
fix geoblocked videoplayer service api

### DIFF
--- a/resources/lib/vtmgostream.py
+++ b/resources/lib/vtmgostream.py
@@ -130,7 +130,7 @@ class VtmGoStream:
                                      },
                                      headers={
                                          'x-api-key': self._VTM_API_KEY,
-                                         'Popcorn-SDK-Version': '1',
+                                         'Popcorn-SDK-Version': '2',
                                          'User-Agent': 'Dalvik/2.1.0 (Linux; U; Android 6.0.1; Nexus 5 Build/M4B30Z)',
                                      },
                                      proxies=proxies)
@@ -146,10 +146,12 @@ class VtmGoStream:
 
     def _extract_anvato_stream_from_stream_info(self, stream_info):
         # Loop over available streams, and return the one from anvato
-        for stream in stream_info['video']['streams']:
-            if stream['type'] == 'anvato':
-                return stream['anvato']
-
+        if stream_info.get('video'):
+            for stream in stream_info.get('video').get('streams'):
+                if stream.get('type') == 'anvato':
+                    return stream.get('anvato')
+        elif stream_info.get('code'):
+            logger.error('VTM GO Videoplayer service API error: %s', stream_info.get('type'))
         raise Exception(localize(30706))  # No stream found that we can handle
 
     def _extract_subtitles_from_stream_info(self, stream_info):

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -4,7 +4,6 @@
 # pylint: disable=missing-docstring
 
 from __future__ import absolute_import, division, print_function, unicode_literals
-import os
 import unittest
 from resources.lib import plugin
 
@@ -104,7 +103,6 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(addon.url_for(plugin.show_tvguide_detail, channel='vtm', date='2019-01-01'), 'plugin://plugin.video.vtm.go/tvguide/vtm/2019-01-01')
 
     # Play Live TV: '/play/livetv/<channel>'
-    @unittest.skipIf(os.environ.get('TRAVIS') == 'true', 'Skipping this test on Travis CI.')
     def test_play_livetv(self):
         plugin.run(['plugin://plugin.video.vtm.go/play/livetv/ea826456-6b19-4612-8969-864d1c818347?.pvr', '0', ''])
         self.assertEqual(

--- a/test/userdata/addon_settings.json
+++ b/test/userdata/addon_settings.json
@@ -6,7 +6,8 @@
     "script.module.inputstreamhelper": {
         "disabled": "false",
         "last_update": "",
-        "version": ""
+        "version": "",
+        "update_frequency": "14"
     },
     "plugin.video.vtm.go": {
         "_comment": "do-not-add-email-and-password-here",


### PR DESCRIPTION
VTM GO Add-on was using a deprecated api version.
It seems, there is no geoblock on the current api version.