### PR TITLE
Check translation during tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
 - tox
 - tox -e flake8
 - pylint *.py resources/lib/ test/
+- make check-translations
 #- kodi-addon-checker . --branch=leia
 - coverage run -m unittest discover
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ package: zip
 
 test: sanity unit run
 
-sanity: tox pylint
+sanity: tox pylint check-translations
 
 tox:
 	@echo -e "$(white)=$(blue) Starting sanity tox test$(reset)"
@@ -36,9 +36,13 @@ pylint:
 	@echo -e "$(white)=$(blue) Starting sanity pylint test$(reset)"
 	pylint *.py resources/lib/ test/
 
+check-translations:
+	@echo -e "$(white)=$(blue) Checking translations$(reset)"
+	msgcmp resources/language/resource.language.nl_nl/strings.po resources/language/resource.language.en_gb/strings.po
+
 addon: clean
 	@echo -e "$(white)=$(blue) Starting sanity addon tests$(reset)"
-	odi-addon-checker . --branch=leia
+	kodi-addon-checker . --branch=leia
 
 unit:
 	@echo -e "$(white)=$(blue) Starting unit tests$(reset)"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -168,10 +168,6 @@ msgctxt "#30708"
 msgid "Please restart Kodi."
 msgstr "Gelieve Kodi te herstarten."
 
-msgctxt "#30708"
-msgid "Please restart Kodi."
-msgstr ""
-
 
 ### SETTINGS
 msgctxt "#30800"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -70,7 +70,7 @@ msgid "TV guide"
 msgstr "Tv-gids"
 
 msgctxt "#30014"
-msgid "Browse the TV guide"
+msgid "Browse the TV Guide"
 msgstr "Doorblader de tv-gids"
 
 ### CODE


### PR DESCRIPTION
This adds msgcmp to the Makefile.

* Check if we have untranslated fields.
* Check for missing translations.

There currently is a duplicate in the nl_nl translation, so this ci should fail.