### PR TITLE
Allow direct playing from epg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ Thumbs.db
 .tox/
 test/userdata/addon_settings.json
 test/userdata/credentials.json
+test/userdata/temp
+test/cdm

--- a/Makefile
+++ b/Makefile
@@ -59,4 +59,3 @@ clean:
 	find . -name '__pycache__' -type d -delete
 	rm -rf .pytest_cache/ .tox/
 	rm -f *.log
-	rm -rf test/userdata/temp

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -134,6 +134,10 @@ msgctxt "#30214"
 msgid "[B]Next:[/B] {start} - {end}\n» {title}\n"
 msgstr ""
 
+msgctxt "#30215"
+msgid "Browse the TV-Guide of [B]{channel}[/B]"
+msgstr ""
+
 
 ### ERRORS
 msgctxt "#30701"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -73,6 +73,7 @@ msgctxt "#30014"
 msgid "Browse the TV Guide"
 msgstr ""
 
+
 ### CODE
 msgctxt "#30200"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
@@ -136,6 +137,28 @@ msgstr ""
 
 msgctxt "#30215"
 msgid "Browse the TV-Guide of [B]{channel}[/B]"
+msgstr ""
+
+
+### Dates
+msgctxt "#30300"
+msgid "2 days ago"
+msgstr ""
+
+msgctxt "#30301"
+msgid "Yesterday"
+msgstr ""
+
+msgctxt "#30302"
+msgid "Today"
+msgstr ""
+
+msgctxt "#30303"
+msgid "Tomorrow"
+msgstr ""
+
+msgctxt "#30304"
+msgid "In 2 days"
 msgstr ""
 
 

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -134,6 +134,10 @@ msgctxt "#30214"
 msgid "[B]Next:[/B] {start} - {end}\n» {title}\n"
 msgstr "[B]Straks:[/B] {start} - {end}\n» {title}\n"
 
+msgctxt "#30215"
+msgid "Browse the TV-Guide of [B]{channel}[/B]"
+msgstr "Doorblader de tv-gids van [B]{channel}[/B]"
+
 
 ### ERRORS
 msgctxt "#30701"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -73,6 +73,7 @@ msgctxt "#30014"
 msgid "Browse the TV guide"
 msgstr "Doorblader de tv-gids"
 
+
 ### CODE
 msgctxt "#30200"
 msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) installed."
@@ -137,6 +138,28 @@ msgstr "[B]Straks:[/B] {start} - {end}\n» {title}\n"
 msgctxt "#30215"
 msgid "Browse the TV-Guide of [B]{channel}[/B]"
 msgstr "Doorblader de tv-gids van [B]{channel}[/B]"
+
+
+### Dates
+msgctxt "#30300"
+msgid "2 days ago"
+msgstr "Eergisteren"
+
+msgctxt "#30301"
+msgid "Yesterday"
+msgstr "Gisteren"
+
+msgctxt "#30302"
+msgid "Today"
+msgstr "Vandaag"
+
+msgctxt "#30303"
+msgid "Tomorrow"
+msgstr "Morgen"
+
+msgctxt "#30304"
+msgid "In 2 days"
+msgstr "Overmorgen"
 
 
 ### ERRORS

--- a/resources/lib/__init__.py
+++ b/resources/lib/__init__.py
@@ -49,7 +49,7 @@ YOUTUBE = [
     ),
     dict(
         label='QMusic',
-        studio='QMusic',
+        studio='Q Music',
         # Q-Music: https://www.youtube.com/user/qmusic
         path='plugin://plugin.video.youtube/user/qmusic/',
         kids=False,
@@ -95,7 +95,7 @@ CHANNELS = [
     ),
     dict(
         label='QMusic',
-        studio='QMusic',
+        studio='Q Music',
         key='qmusic',
         kids=False,
     ),

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -217,7 +217,6 @@ def show_tvguide():
 @plugin.route('/tvguide/<channel>')
 def show_tvguide_channel(channel):
     listing = []
-    kids = _get_kids_mode()
 
     for day in VtmGoEpg.get_dates():
         if day['highlight']:

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -221,8 +221,6 @@ def show_tvguide(channel=None):
         # Sort like we add it.
         xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_UNSORTED)
 
-        xbmcplugin.setContent(plugin.handle, 'files')
-
     xbmcplugin.setPluginCategory(plugin.handle, category='VTM KIDS / TV Guide' if kids else 'VTM GO / TV Guide')
     ok = xbmcplugin.addDirectoryItems(plugin.handle, listing, len(listing))
     xbmcplugin.endOfDirectory(plugin.handle, ok, cacheToDisc=True)
@@ -266,7 +264,7 @@ def show_tvguide_detail(channel=None, date=None):
 
     xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_UNSORTED)
     xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL)
-    xbmcplugin.setPluginCategory(plugin.handle, category='VTM GO / TV Guide')
+    xbmcplugin.setPluginCategory(plugin.handle, category=date)
     ok = xbmcplugin.addDirectoryItems(plugin.handle, listing, len(listing))
     xbmcplugin.endOfDirectory(plugin.handle, ok, cacheToDisc=False)
 

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -11,7 +11,7 @@ from resources.lib.kodiutils import (get_cond_visibility, get_max_bandwidth, get
                                      get_setting_as_bool, get_global_setting, localize,
                                      notification, show_ok_dialog, show_settings)
 from resources.lib.vtmgo import Content, VtmGo
-from resources.lib.vtmgoepg import VtmGoEpg, EpgBroadcast
+from resources.lib.vtmgoepg import VtmGoEpg
 from resources.lib.vtmgostream import VtmGoStream
 
 plugin = routing.Plugin()
@@ -211,7 +211,6 @@ def show_tvguide(channel=None):
         xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL)
 
     else:
-        from .vtmgoepg import VtmGoEpg
         for day in VtmGoEpg.get_dates():
             listitem = ListItem(day.get('title'), offscreen=True)
             listitem.setInfo('video', {
@@ -232,7 +231,6 @@ def show_tvguide(channel=None):
 @plugin.route('/tvguide/<channel>/<date>')
 def show_tvguide_detail(channel=None, date=None):
     try:
-        from .vtmgoepg import VtmGoEpg
         _vtmGoEpg = VtmGoEpg()
         epg = _vtmGoEpg.get_epg(date=date)
     except Exception as ex:

--- a/resources/lib/vtmgo.py
+++ b/resources/lib/vtmgo.py
@@ -3,6 +3,8 @@
 from __future__ import absolute_import, division, unicode_literals
 import json
 
+from resources.lib import kodilogging
+
 try:  # Python 3
     from urllib.parse import quote
 except ImportError:  # Python 2
@@ -361,6 +363,8 @@ class VtmGo:
         }
         if auth:
             headers['x-dpp-jwt'] = auth
+
+        kodilogging.log('Fetching %s...' % url, kodilogging.LOGDEBUG)
 
         response = requests.session().get('https://api.vtmgo.be' + url, headers=headers, verify=False, proxies=proxies)
 

--- a/resources/lib/vtmgo.py
+++ b/resources/lib/vtmgo.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, unicode_literals
-import json
 
-from resources.lib import kodilogging
+import json
 
 try:  # Python 3
     from urllib.parse import quote
@@ -11,6 +10,7 @@ except ImportError:  # Python 2
     from urllib import quote
 
 import requests
+from resources.lib import kodilogging
 from resources.lib.kodiutils import proxies
 
 

--- a/resources/lib/vtmgoepg.py
+++ b/resources/lib/vtmgoepg.py
@@ -10,6 +10,7 @@ import dateutil.tz
 import requests
 
 from resources.lib import kodilogging
+from resources.lib.kodiutils import localize
 
 
 class EpgChannel:
@@ -138,27 +139,35 @@ class VtmGoEpg:
 
     @staticmethod
     def get_dates():
-        dates = []
+        import xbmc
 
+        dates = []
         today = datetime.today()
 
         # The API provides 2 days in the past and 7 days in the future
         for i in range(-2, 7):
             day = today + timedelta(days=i)
 
-            # TODO: make this pretty
             if i == -1:
-                title = 'Yesterday'
+                title = '%s, %s' % (localize(30301), day.strftime(xbmc.getRegion('datelong')))  # Yesterday
+                # date = 'yesterday'
+                highlight = False
             elif i == 0:
-                title = 'Today'
+                title = '%s, %s' % (localize(30302), day.strftime(xbmc.getRegion('datelong')))  # Today
+                # date = 'today'
+                highlight = True
             elif i == 1:
-                title = 'Tomorrow'
+                title = '%s, %s' % (localize(30303), day.strftime(xbmc.getRegion('datelong')))  # Tomorrow
+                # date = 'tomorrow'
+                highlight = False
             else:
-                title = day.strftime('%Y-%m-%d')
+                title = day.strftime(xbmc.getRegion('datelong'))
+                highlight = False
 
             dates.append({
                 'title': title,
                 'date': day.strftime('%Y-%m-%d'),
+                'highlight': highlight,
             })
 
         return dates

--- a/resources/lib/vtmgoepg.py
+++ b/resources/lib/vtmgoepg.py
@@ -6,7 +6,10 @@ import json
 from datetime import datetime, timedelta
 
 import dateutil.parser
+import dateutil.tz
 import requests
+
+from resources.lib import kodilogging
 
 
 class EpgChannel:
@@ -17,11 +20,15 @@ class EpgChannel:
         self.logo = logo
         self.broadcasts = broadcasts
 
+    def __repr__(self):
+        return "%r" % self.__dict__
+
 
 class EpgBroadcast:
-    def __init__(self, uuid=None, mediatype=None, title=None, time=None, duration=None, image=None, description=None, live=None, rerun=None, tip=None):
+    def __init__(self, uuid=None, playable_type=None, title=None, time=None, duration=None, image=None, description=None, live=None, rerun=None, tip=None,
+                 program_uuid=None, playable_uuid=None):
         self.uuid = uuid
-        self.mediatype = mediatype
+        self.playable_type = playable_type
         self.title = title
         self.time = time
         self.duration = duration
@@ -31,12 +38,16 @@ class EpgBroadcast:
         self.rerun = rerun
         self.tip = tip
 
+        self.program_uuid = program_uuid
+        self.playable_uuid = playable_uuid
+
     def __repr__(self):
         return "%r" % self.__dict__
 
 
 class VtmGoEpg:
     EPG_URL = 'https://vtm.be/tv-gids/api/v2/broadcasts/{date}'
+    DETAILS_URL = 'https://vtm.be/tv-gids/{channel}/uitzending/{type}/{uuid}'
 
     def __init__(self):
         self._session = requests.session()
@@ -44,12 +55,17 @@ class VtmGoEpg:
     def get_epg(self, date=None):
         # TODO: implement caching
 
+        # Fetch today when no date is specified
         if date is None:
             date = datetime.today().strftime('%Y-%m-%d')
 
-        response = self._session.get(self.EPG_URL.format(date=date))
+        url = self.EPG_URL.format(date=date)
+
+        kodilogging.log('Fetching %s...' % url, kodilogging.LOGDEBUG)
+
+        response = self._session.get(url)
         if response.status_code != 200:
-            raise Exception('Error %s in _get_epg when fetching %s.' % (response.status_code, self.EPG_URL.format(date=date)))
+            raise Exception('Error %s while fetching EPG data.' % response.status_code)
 
         epg = json.loads(response.text)
 
@@ -65,9 +81,41 @@ class VtmGoEpg:
 
         return result
 
+    def get_details(self, channel, program_type, epg_id):
+        import re
+
+        # Do mapping
+        if program_type == 'episodes':
+            url = self.DETAILS_URL.format(channel=channel, type='aflevering', uuid=epg_id)
+        elif program_type == 'movies':
+            url = self.DETAILS_URL.format(channel=channel, type='film', uuid=epg_id)
+        elif program_type == 'oneoffs':
+            url = self.DETAILS_URL.format(channel=channel, type='oneoff', uuid=epg_id)
+        else:
+            raise Exception('Unknown broadcast type %s.' % program_type)
+
+        # Add cookies
+        self._session.cookies.set('pws', 'functional|analytics|content_recommendation|targeted_advertising|social_media')
+        self._session.cookies.set('pwv', '1')
+
+        # Fetch data
+        kodilogging.log('Fetching %s...' % url, kodilogging.LOGDEBUG)
+        response = self._session.get(url, )
+        if response.status_code != 200:
+            raise Exception('Error %s while fetching EPG details.' % response.status_code)
+
+        # Extract data
+        matches = re.search(r'EPG_REDUX_DATA=([^;]+);', response.content)
+        if not matches:
+            raise Exception('Could not parse EPG details.')
+
+        # Parse data
+        data = json.loads(matches.group(1))
+
+        return self._parse_broadcast(data['details'][epg_id])
+
     @staticmethod
     def _parse_broadcast(broadcast_json):
-
         # Sometimes, the duration field is empty, but luckily, we can calculate it.
         duration = broadcast_json.get('duration')
         if duration is None:
@@ -75,15 +123,17 @@ class VtmGoEpg:
 
         return EpgBroadcast(
             uuid=broadcast_json.get('uuid'),
-            mediatype=broadcast_json.get('playableType'),
+            playable_type=broadcast_json.get('playableType'),
+            playable_uuid=broadcast_json.get('playableUuid'),
             title=broadcast_json.get('title'),
-            time=dateutil.parser.parse(broadcast_json.get('fromIso')),
+            time=dateutil.parser.isoparse(broadcast_json.get('fromIso') + 'Z').astimezone(dateutil.tz.gettz('CET')),
             duration=duration,
             image=broadcast_json.get('imageUrl'),
             description=broadcast_json.get('synopsis'),
             live=broadcast_json.get('live'),
             rerun=broadcast_json.get('rerun'),
             tip=broadcast_json.get('tip'),
+            program_uuid=broadcast_json.get('programUuid'),
         )
 
     @staticmethod

--- a/resources/lib/vtmgoepg.py
+++ b/resources/lib/vtmgoepg.py
@@ -105,7 +105,7 @@ class VtmGoEpg:
             raise Exception('Error %s while fetching EPG details.' % response.status_code)
 
         # Extract data
-        matches = re.search(r'EPG_REDUX_DATA=([^;]+);', response.content)
+        matches = re.search(r'EPG_REDUX_DATA=([^;]+);', response.content.decode('utf-8'))
         if not matches:
             raise Exception('Could not parse EPG details.')
 

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -103,6 +103,7 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(addon.url_for(plugin.show_tvguide_detail, channel='vtm', date='2019-01-01'), 'plugin://plugin.video.vtm.go/tvguide/vtm/2019-01-01')
 
     # Play Live TV: '/play/livetv/<channel>'
+    @unittest.skipIf(os.environ.get('TRAVIS') == 'true', 'Skipping this test on Travis CI.')
     def test_play_livetv(self):
         plugin.run(['plugin://plugin.video.vtm.go/play/livetv/ea826456-6b19-4612-8969-864d1c818347?.pvr', '0', ''])
         self.assertEqual(

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -100,7 +100,7 @@ class TestRouter(unittest.TestCase):
         plugin.run(['plugin://plugin.video.vtm.go/kids/tvguide', '0', ''])
         self.assertEqual(addon.url_for(plugin.show_kids_tvguide), 'plugin://plugin.video.vtm.go/kids/tvguide')
         plugin.run(['plugin://plugin.video.vtm.go/tvguide/vtm', '0', ''])
-        self.assertEqual(addon.url_for(plugin.show_tvguide, channel='vtm'), 'plugin://plugin.video.vtm.go/tvguide/vtm')
+        self.assertEqual(addon.url_for(plugin.show_tvguide_channel, channel='vtm'), 'plugin://plugin.video.vtm.go/tvguide/vtm')
         # plugin.run(['plugin://plugin.video.vtm.go/tvguide/vtm/2019-01-01', '0', ''])
         self.assertEqual(addon.url_for(plugin.show_tvguide_detail, channel='vtm', date='2019-01-01'), 'plugin://plugin.video.vtm.go/tvguide/vtm/2019-01-01')
 

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -4,6 +4,8 @@
 # pylint: disable=missing-docstring
 
 from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
 import unittest
 from resources.lib import plugin
 

--- a/test/test_vtmgo.py
+++ b/test/test_vtmgo.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
 import json
-import logging
 import unittest
 
 from resources.lib import vtmgo, vtmgoauth, vtmgostream

--- a/test/test_vtmgo.py
+++ b/test/test_vtmgo.py
@@ -8,7 +8,7 @@ import json
 import logging
 import unittest
 
-from resources.lib import vtmgo, vtmgoepg, vtmgoauth, vtmgostream
+from resources.lib import vtmgo, vtmgoauth, vtmgostream
 from resources.lib.kodilogging import getLogger
 
 logger = getLogger('TestVtmGo')
@@ -21,7 +21,7 @@ class TestVtmGo(unittest.TestCase):
 
         self._token = None
         self._vtmgo = vtmgo.VtmGo()
-        self._vtmgoepg = vtmgoepg.VtmGoEpg()
+        self._vtmgostream = vtmgostream.VtmGoStream()
 
         try:
             with open('test/userdata/credentials.json') as f:
@@ -32,21 +32,19 @@ class TestVtmGo(unittest.TestCase):
             self._vtmgoauth = None
             self._SETTINGS = None
 
-        self._vtmgostream = vtmgostream.VtmGoStream()
-
         # Enable debug logging for urllib
-        try:
-            import http.client as http_client
-        except ImportError:
-            # Python 2
-            import httplib as http_client
-        http_client.HTTPConnection.debuglevel = 1
-
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
-        requests_log = logging.getLogger("requests.packages.urllib3")
-        requests_log.setLevel(logging.DEBUG)
-        requests_log.propagate = True
+        # try:
+        #     import http.client as http_client
+        # except ImportError:
+        #     # Python 2
+        #     import httplib as http_client
+        # http_client.HTTPConnection.debuglevel = 1
+        #
+        # logging.basicConfig()
+        # logging.getLogger().setLevel(logging.DEBUG)
+        # requests_log = logging.getLogger("requests.packages.urllib3")
+        # requests_log.setLevel(logging.DEBUG)
+        # requests_log.propagate = True
 
     def test_login(self):
         if self._vtmgoauth is not None:
@@ -96,10 +94,6 @@ class TestVtmGo(unittest.TestCase):
         info = self._vtmgostream.get_stream('channels', 'd8659669-b964-414c-aa9c-e31d8d15696b')
         self.assertTrue(info)
         print(info)
-
-    def test_get_epg(self):
-        epg = self._vtmgoepg.get_epg()
-        print(epg)
 
     def test_get_stream_with_subtitles(self):
         # 13 Geboden - Episode 2

--- a/test/test_vtmgoepg.py
+++ b/test/test_vtmgoepg.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+# pylint: disable=missing-docstring
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+from resources.lib import vtmgoepg
+from resources.lib.kodilogging import getLogger
+
+logger = getLogger('TestVtmGoEpg')
+
+
+class TestVtmGoEpg(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(TestVtmGoEpg, self).__init__(*args, **kwargs)
+        self._vtmgoepg = vtmgoepg.VtmGoEpg()
+
+        # Enable debug logging for urllib
+        # try:
+        #     import http.client as http_client
+        # except ImportError:
+        #     # Python 2
+        #     import httplib as http_client
+        # http_client.HTTPConnection.debuglevel = 1
+        #
+        # logging.basicConfig()
+        # logging.getLogger().setLevel(logging.DEBUG)
+        # requests_log = logging.getLogger("requests.packages.urllib3")
+        # requests_log.setLevel(logging.DEBUG)
+        # requests_log.propagate = True
+
+    def test_get_epg(self):
+        # Get list of EPG for today
+        epg = self._vtmgoepg.get_epg()
+        self.assertTrue(epg)
+
+        # Take first broadcast of vtm
+        # TODO: extend test to keep trying next episodes until we have one with a playableUuid
+        first = epg['vtm'].broadcasts[0]
+
+        # Fetch details
+        details = self._vtmgoepg.get_details(channel='vtm', program_type=first.playable_type, epg_id=first.uuid)
+        self.assertTrue(details)
+        print(details)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This allows to play items directly from the EPG.

A few things I've noticed:
* All items seems to get a `playable_uuid` when scraped from the html, even shows in the future. We can't know for sure if it is playable until we actually ask anvato for the stream. We get a 502 in `_get_stream_info()` when the stream doesn't exists yet.
* The breadcrumb shows "Series / VTM GO / VTM GO / TV Guide", not sure why other sections don't do this.

Fixes #66 
Fixes #72