### PR TITLE
Don't error out on geoblocked content

### DIFF
--- a/resources/lib/vtmgostream.py
+++ b/resources/lib/vtmgostream.py
@@ -50,6 +50,8 @@ class VtmGoStream:
     def get_stream(self, stream_type, stream_id):
         # We begin with asking vtm about the stream info.
         stream_info = self._get_stream_info(stream_type, stream_id)
+        if stream_info is None:
+            return None  # No stream available (i.e. geo-blocked)
 
         # Extract the anvato stream from our stream_info.
         anvato_info = self._extract_anvato_stream_from_stream_info(stream_info)
@@ -136,6 +138,7 @@ class VtmGoStream:
                                      proxies=proxies)
 
         if response.status_code == 403:
+            logger.error('Error %s in _get_stream_info.', response.status_code)
             show_ok_dialog(heading='HTTP 403 Forbidden', message=localize(30704))  # Geo-blocked
             return None
         if response.status_code != 200:

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
 import unittest
 from resources.lib import plugin
 
@@ -105,7 +104,6 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(addon.url_for(plugin.show_tvguide_detail, channel='vtm', date='today'), 'plugin://plugin.video.vtm.go/tvguide/vtm/today')
 
     # Play Live TV: '/play/livetv/<channel>'
-    @unittest.skipIf(os.environ.get('TRAVIS') == 'true', 'Skipping this test on Travis CI.')
     def test_play_livetv(self):
         plugin.run(['plugin://plugin.video.vtm.go/play/livetv/ea826456-6b19-4612-8969-864d1c818347?.pvr', '0', ''])
         self.assertEqual(


### PR DESCRIPTION
It seems we got a 403 in `_get_stream_info()`. This is now handled in `get_stream()` so we don't get a stacktrace.

I still don't know if we can play content outside Belgium or even EU. I don't have a proxy to test this.

Fixes #65 