### PR TITLE
Enable reuselanguageinvoker

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -31,5 +31,6 @@ First release
         <assets>
             <icon>resources/icon.png</icon>
         </assets>
+        <reuselanguageinvoker>true</reuselanguageinvoker>
     </extension>
 </addon>


### PR DESCRIPTION
Enable reuselanguageinvoker for a big speedup. One drawback is that it also caches the plugin during development.