### PR TITLE
Show correct error messages when geoblocked or when unavailable.

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -92,7 +92,7 @@ msgid "Your credentials are not valid!"
 msgstr ""
 
 msgctxt "#30204"
-msgid "* All seasons"
+msgid "All seasons"
 msgstr ""
 
 msgctxt "#30205"
@@ -197,6 +197,22 @@ msgstr ""
 
 msgctxt "#30708"
 msgid "Please restart Kodi."
+msgstr ""
+
+msgctxt "#30709"
+msgid "Geo-blocked video"
+msgstr ""
+
+msgctxt "#30710"
+msgid "This video is geo-blocked and can't be played from your location."
+msgstr ""
+
+msgctxt "#30711"
+msgid "Unavailable video"
+msgstr ""
+
+msgctxt "#30712"
+msgid "The video is unavailable and can't be played right now."
 msgstr ""
 
 

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -92,8 +92,8 @@ msgid "Your credentials are not valid!"
 msgstr "De VTM GO inloggegevens zijn onjuist!"
 
 msgctxt "#30204"
-msgid "* All seasons"
-msgstr "* Alle seizoenen"
+msgid "All seasons"
+msgstr "Alle seizoenen"
 
 msgctxt "#30205"
 msgid "Season {season}"
@@ -198,6 +198,22 @@ msgstr "Niet-ondersteunde videoType {type}"
 msgctxt "#30708"
 msgid "Please restart Kodi."
 msgstr "Gelieve Kodi te herstarten."
+
+msgctxt "#30709"
+msgid "Geo-blocked video"
+msgstr "Video is geografisch geblokkeerd"
+
+msgctxt "#30710"
+msgid "This video is geo-blocked and can't be played from your location."
+msgstr "Deze video is geografisch geblokkeerd en kan niet worden afgespeeld vanaf je locatie."
+
+msgctxt "#30711"
+msgid "Unavailable video"
+msgstr "Onbeschikbare video"
+
+msgctxt "#30712"
+msgid "The video is unavailable and can't be played right now."
+msgstr "Deze video is niet beschikbaar en kan nu niet worden afgespeeld."
 
 
 ### SETTINGS

--- a/resources/lib/__init__.py
+++ b/resources/lib/__init__.py
@@ -108,3 +108,11 @@ CHANNELS = [
         kids=False,
     ),
 ]
+
+
+class GeoblockedException(Exception):
+    pass
+
+
+class UnavailableException(Exception):
+    pass

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -47,7 +47,7 @@ class TestRouter(unittest.TestCase):
     def test_program_season_menu(self):
         plugin.run(['plugin://plugin.video.vtm.go/program/e892cf10-5100-42ce-8d59-6b5c03cc2b96/all', '0', ''])
         self.assertEqual(
-            addon.url_for(plugin.show_program, program='e892cf10-5100-42ce-8d59-6b5c03cc2b96', season='all'),
+            addon.url_for(plugin.show_program_season, program='e892cf10-5100-42ce-8d59-6b5c03cc2b96', season='all'),
             'plugin://plugin.video.vtm.go/program/e892cf10-5100-42ce-8d59-6b5c03cc2b96/all')
 
     # Catalogue menu: '/catalog'
@@ -95,24 +95,24 @@ class TestRouter(unittest.TestCase):
 
     # Play Live TV: '/play/livetv/<channel>'
     def test_play_livetv(self):
-        plugin.run(['plugin://plugin.video.vtm.go/play/livetv/ea826456-6b19-4612-8969-864d1c818347?.pvr', '0', ''])
+        plugin.run(['plugin://plugin.video.vtm.go/play/channels/ea826456-6b19-4612-8969-864d1c818347?.pvr', '0', ''])
         self.assertEqual(
-            addon.url_for(plugin.play_livetv, channel='ea826456-6b19-4612-8969-864d1c818347?.pvr'),
-            'plugin://plugin.video.vtm.go/play/livetv/ea826456-6b19-4612-8969-864d1c818347?.pvr')
+            addon.url_for(plugin.play, category='channels', item='ea826456-6b19-4612-8969-864d1c818347?.pvr'),
+            'plugin://plugin.video.vtm.go/play/channels/ea826456-6b19-4612-8969-864d1c818347?.pvr')
 
     # Play Movie: '/play/movie/<movie>'
     def test_play_movie(self):
-        plugin.run(['plugin://plugin.video.vtm.go/play/movie/d1850498-941d-48cc-a558-37aaf37f4525', '0', ''])
+        plugin.run(['plugin://plugin.video.vtm.go/play/movies/d1850498-941d-48cc-a558-37aaf37f4525', '0', ''])
         self.assertEqual(
-            addon.url_for(plugin.play_movie, movie='d1850498-941d-48cc-a558-37aaf37f4525'),
-            'plugin://plugin.video.vtm.go/play/movie/d1850498-941d-48cc-a558-37aaf37f4525')
+            addon.url_for(plugin.play, category='movies', item='d1850498-941d-48cc-a558-37aaf37f4525'),
+            'plugin://plugin.video.vtm.go/play/movies/d1850498-941d-48cc-a558-37aaf37f4525')
 
     # Play Episode: '/play/episode/<episode>'
     def test_play_episode(self):
-        plugin.run(['plugin://plugin.video.vtm.go/play/episode/ae0fa98d-6ed5-4f4a-8581-a051ed3bb755', '0', ''])
+        plugin.run(['plugin://plugin.video.vtm.go/play/episodes/ae0fa98d-6ed5-4f4a-8581-a051ed3bb755', '0', ''])
         self.assertEqual(
-            addon.url_for(plugin.play_episode, episode='ae0fa98d-6ed5-4f4a-8581-a051ed3bb755'),
-            'plugin://plugin.video.vtm.go/play/episode/ae0fa98d-6ed5-4f4a-8581-a051ed3bb755')
+            addon.url_for(plugin.play, category='episodes', item='ae0fa98d-6ed5-4f4a-8581-a051ed3bb755'),
+            'plugin://plugin.video.vtm.go/play/episodes/ae0fa98d-6ed5-4f4a-8581-a051ed3bb755')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Shows correct error messages when a video is geoblocked or when it's just unavailable.
* Fixes playing programs from the EPG that are not available in the VTM GO API.
* Renames some variables.
* Fixes a few translations.
* Various other small metadata fixes.
* Merge the `play_*` functions to a single `play` function.