### PR TITLE
Add Catalog to Channel menu

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -104,6 +104,14 @@ msgctxt "#30054"
 msgid "Browse the TV Guide for [B]{channel}[/B]"
 msgstr ""
 
+msgctxt "#30055"
+msgid "Catalog for [B]{channel}[/B]"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Browse the Catalog for [B]{channel}[/B]"
+msgstr ""
+
 
 ### CONTEXT MENU
 
@@ -333,10 +341,6 @@ msgstr ""
 
 msgctxt "#30829"
 msgid "Periodically refresh metadata in the background"
-msgstr ""
-
-msgctxt "#30830"
-msgid "Periodically refresh metadata in the background HELP"
 msgstr ""
 
 msgctxt "#30831"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -105,6 +105,14 @@ msgctxt "#30054"
 msgid "Browse the TV Guide for [B]{channel}[/B]"
 msgstr "Doorblader de TV-gids voor [B]{channel}[/B]"
 
+msgctxt "#30055"
+msgid "Catalog for [B]{channel}[/B]"
+msgstr "Catalogus voor [B]{channel}[/B]"
+
+msgctxt "#30056"
+msgid "Browse the Catalog for [B]{channel}[/B]"
+msgstr "Doorblader de catalogus voor [B]{channel}[/B]"
+
 
 ### CONTEXT MENU
 
@@ -333,11 +341,7 @@ msgstr "Metadata"
 
 msgctxt "#30829"
 msgid "Periodically refresh metadata in the background"
-msgstr "Vernieuw de locale metdata automatisch in de achtergrond"
-
-msgctxt "#30830"
-msgid "Periodically refresh metadata in the background HELP"
-msgstr "Vernieuw de locale metdata automatisch in de achtergrond HELP"
+msgstr "Vernieuw de metdata automatisch in de achtergrond"
 
 msgctxt "#30831"
 msgid "Update local metadata now"

--- a/resources/lib/modules/catalog.py
+++ b/resources/lib/modules/catalog.py
@@ -41,7 +41,7 @@ class Catalog:
         # Sort categories by default like in VTM GO.
         self._kodi.show_listing(listing, 30003, content='files')
 
-    def show_catalog_category(self, category):
+    def show_catalog_category(self, category=None):
         """ Show a category in the catalog
         :type category: str
         """
@@ -58,6 +58,24 @@ class Catalog:
         # Sort items by label, but don't put folders at the top.
         # Used for A-Z listing or when movies and episodes are mixed.
         self._kodi.show_listing(listing, 30003, content='movies' if category == 'films' else 'tvshows', sort='label')
+
+    def show_catalog_channel(self, channel):
+        """ Show a category in the catalog
+        :type channel: str
+        """
+        try:
+            items = self._vtm_go.get_items()
+        except Exception as ex:
+            self._kodi.show_notification(message=str(ex))
+            raise
+
+        listing = []
+        for item in items:
+            listing.append(self._menu.generate_titleitem(item)) if item.channel == channel else None
+
+        # Sort items by label, but don't put folders at the top.
+        # Used for A-Z listing or when movies and episodes are mixed.
+        self._kodi.show_listing(listing, 30003, content='tvshows', sort='label')
 
     def show_program(self, program):
         """ Show a program from the catalog

--- a/resources/lib/modules/catalog.py
+++ b/resources/lib/modules/catalog.py
@@ -71,7 +71,8 @@ class Catalog:
 
         listing = []
         for item in items:
-            listing.append(self._menu.generate_titleitem(item)) if item.channel == channel else None
+            if item.channel == channel:
+                listing.append(self._menu.generate_titleitem(item))
 
         # Sort items by label, but don't put folders at the top.
         # Used for A-Z listing or when movies and episodes are mixed.

--- a/resources/lib/modules/channels.py
+++ b/resources/lib/modules/channels.py
@@ -42,14 +42,22 @@ class Channels:
             fanart = '{path}/resources/logos/{logo}.png'.format(path=self._kodi.get_addon_path(), logo=channel.get('logo'))
 
             context_menu = [(
-                self._kodi.localize(30103),  # Watch live
+                self._kodi.localize(30052, channel=channel.get('label')),  # Watch live channel
                 'XBMC.PlayMedia(%s)' %
                 self._kodi.url_for('play', category='channels', item=channel_info.channel_id)
             ), (
-                self._kodi.localize(30104),  # TV Guide
+                self._kodi.localize(30053, channel=channel.get('label')),  # TV Guide for channel
                 'XBMC.Container.Update(%s)' %
                 self._kodi.url_for('show_tvguide_channel', channel=channel.get('epg'))
             )]
+            if self._kodi.get_setting_as_bool('metadata_update'):
+                context_menu.append(
+                    (
+                        self._kodi.localize(30055, channel=channel.get('label')),  # Catalog for channel
+                        'XBMC.Container.Update(%s)' %
+                        self._kodi.url_for('show_catalog_channel', channel=key)
+                    )
+                )
 
             title = channel.get('label')
             if channel_info and channel_info.epg:
@@ -125,11 +133,22 @@ class Channels:
                       }),
         ]
 
-        # Add YouTube channels
+        if self._kodi.get_setting_as_bool('metadata_update'):
+            listing.append(
+                TitleItem(title=self._kodi.localize(30055, channel=channel.get('label')),
+                          path=self._kodi.url_for('show_catalog_channel', channel=key),
+                          art_dict={
+                              'icon': 'DefaultMovieTitle.png'
+                          },
+                          info_dict={
+                              'plot': self._kodi.localize(30056, channel=channel.get('label')),
+                          }))
+
+            # Add YouTube channels
         if self._kodi.get_cond_visibility('System.HasAddon(plugin.video.youtube)') != 0:
             for youtube in channel.get('youtube', []):
                 listing.append(
-                    TitleItem(title='[B]{channel}[/B] on YouTube'.format(channel=youtube.get('label')),
+                    TitleItem(title=self._kodi.localize(30206, label=youtube.get('label')),
                               path=youtube.get('path'),
                               info_dict={
                                   'plot': self._kodi.localize(30206, label=youtube.get('label')),

--- a/resources/lib/modules/menu.py
+++ b/resources/lib/modules/menu.py
@@ -26,7 +26,7 @@ class Menu:
         listing = []
         listing.append(
             TitleItem(title=self._kodi.localize(30001),  # A-Z
-                      path=self._kodi.url_for('show_catalog_category', kids=kids, category='all'),
+                      path=self._kodi.url_for('show_catalog_all', kids=kids),
                       art_dict=dict(
                           icon='DefaultMovieTitle.png'
                       ),
@@ -203,24 +203,18 @@ class Menu:
                     self._kodi.url_for('mylist_add', kids=self._kodi.kids_mode(), video_type=self._vtm_go.CONTENT_TYPE_MOVIE, content_id=item.movie_id)
                 )]
 
+            art_dict.update({
+                'fanart': item.cover,
+            })
             info_dict.update({
                 'mediatype': 'movie',
+                'plot': self.format_plot(item),
+                'duration': item.duration,
+                'year': item.year,
+                'aired': item.aired,
+                'studio': CHANNELS.get(item.channel, {}).get('studio_icon'),
+                'mpaa': ', '.join(item.legal) if hasattr(item, 'legal') and item.legal else self._kodi.localize(30216),
             })
-
-            # Get movie details from cache
-            movie = self._vtm_go.get_movie(item.movie_id, only_cache=True)
-            if movie:
-                art_dict.update({
-                    'fanart': movie.cover,
-                })
-                info_dict.update({
-                    'plot': self.format_plot(movie),
-                    'duration': movie.duration,
-                    'year': movie.year,
-                    'aired': movie.aired,
-                    'studio': CHANNELS.get(movie.channel, {}).get('studio_icon'),
-                    'mpaa': ', '.join(movie.legal) if hasattr(movie, 'legal') and movie.legal else self._kodi.localize(30216),
-                })
 
             return TitleItem(title=item.name,
                              path=self._kodi.url_for('play', category='movies', item=item.movie_id),
@@ -251,24 +245,18 @@ class Menu:
                     self._kodi.url_for('mylist_add', kids=self._kodi.kids_mode(), video_type=self._vtm_go.CONTENT_TYPE_PROGRAM, content_id=item.program_id)
                 )]
 
+            art_dict.update({
+                'fanart': item.cover,
+                'banner': item.cover,
+            })
             info_dict.update({
                 'mediatype': None,
+                'title': item.name,
+                'plot': self.format_plot(item),
+                'studio': CHANNELS.get(item.channel, {}).get('studio_icon'),
+                'mpaa': ', '.join(item.legal) if hasattr(item, 'legal') and item.legal else self._kodi.localize(30216),
+                'season': len(item.seasons),
             })
-
-            # Get program details from cache
-            program = self._vtm_go.get_program(item.program_id, only_cache=True)
-            if program:
-                art_dict.update({
-                    'fanart': program.cover,
-                    'banner': item.cover,
-                })
-                info_dict.update({
-                    'title': program.name,
-                    'plot': self.format_plot(program),
-                    'studio': CHANNELS.get(program.channel, {}).get('studio_icon'),
-                    'mpaa': ', '.join(program.legal) if hasattr(program, 'legal') and program.legal else self._kodi.localize(30216),
-                    'season': len(program.seasons),
-                })
 
             return TitleItem(title=item.name,
                              path=self._kodi.url_for('show_catalog_program', program=item.program_id),
@@ -313,7 +301,7 @@ class Menu:
             }
 
             # Get program and episode details from cache
-            program = self._vtm_go.get_program(item.program_id, only_cache=True)
+            program = self._vtm_go.get_program(item.program_id, cache=True)
             if program:
                 episode = self._vtm_go.get_episode_from_program(program, item.episode_id)
                 if episode:

--- a/resources/lib/modules/metadata.py
+++ b/resources/lib/modules/metadata.py
@@ -34,16 +34,16 @@ class Metadata:
         :type callback: callable
         """
         # Fetch all items from the catalog
-        items = self._vtm_go.get_items('all')
+        items = self._vtm_go.get_items()
         count = len(items)
 
         # Loop over all of them and download the metadata
         for index, item in enumerate(items):
             if isinstance(item, Movie):
-                if not self._vtm_go.get_movie(item.movie_id, only_cache=True):
+                if not self._vtm_go.get_movie(item.movie_id, cache=True):
                     self._vtm_go.get_movie(item.movie_id)
             elif isinstance(item, Program):
-                if not self._vtm_go.get_program(item.program_id, only_cache=True):
+                if not self._vtm_go.get_program(item.program_id, cache=True):
                     self._vtm_go.get_program(item.program_id)
 
             # Update the progress indicator

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -60,11 +60,25 @@ def show_catalog():
     Catalog(kodi).show_catalog()
 
 
-@routing.route('/catalog/category/<category>')
+@routing.route('/catalog/all')
+def show_catalog_all():
+    """ Show a category in the catalog """
+    from resources.lib.modules.catalog import Catalog
+    Catalog(kodi).show_catalog_category()
+
+
+@routing.route('/catalog/by-category/<category>')
 def show_catalog_category(category):
     """ Show a category in the catalog """
     from resources.lib.modules.catalog import Catalog
     Catalog(kodi).show_catalog_category(category)
+
+
+@routing.route('/catalog/by-channel/<channel>')
+def show_catalog_channel(channel):
+    """ Show a category in the catalog """
+    from resources.lib.modules.catalog import Catalog
+    Catalog(kodi).show_catalog_channel(channel)
 
 
 @routing.route('/catalog/program/<program>')

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -16,7 +16,7 @@
         <setting label="30824" type="bool" id="interface_show_kids_zone" default="true" enable="eq(1,false)"/>
         <setting label="30825" type="bool" id="interface_force_kids_zone" default="false"/>
         <setting label="30827" type="lsep"/> <!-- Metadata -->
-        <setting label="30829" type="bool" id="metadata_update" default="false" subsetting="true"/>
+        <setting label="30829" type="bool" id="metadata_update" default="true" subsetting="true"/>
         <setting label="30831" type="action" option="close" action="RunPlugin(plugin://plugin.video.vtm.go/metadata/update)"/>
         <setting label="30833" type="action" option="close" action="RunPlugin(plugin://plugin.video.vtm.go/metadata/clean)"/>
     </category>

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -52,6 +52,9 @@ class TestRouting(unittest.TestCase):
         plugin.run([routing.url_for(plugin.show_catalog_category, category='kids'), '0', ''])
         plugin.run([routing.url_for(plugin.show_catalog_category, category='nieuws-actua'), '0', ''])
 
+    def test_catalog_channel_menu(self):
+        plugin.run([routing.url_for(plugin.show_catalog_channel, channel='vtm'), '0', ''])
+
     def test_catalog_program_menu(self):
         plugin.run([routing.url_for(plugin.show_catalog_program, program='e892cf10-5100-42ce-8d59-6b5c03cc2b96'), '0', ''])
 

--- a/test/test_vtmgo.py
+++ b/test/test_vtmgo.py
@@ -51,7 +51,7 @@ class TestVtmGo(unittest.TestCase):
         self.assertTrue(categories)
         # print(categories)
 
-        items = self._vtmgo.get_items('all')
+        items = self._vtmgo.get_items()
         self.assertTrue(items)
         # print(items)
 


### PR DESCRIPTION
Adds a "Catalog for {channel}" item in the Channel menu. This uses the locally cached metadata of the full catalog to filter out a list of programs per channel. It's added in an additional menu entry to keep the channel menu fast, and so we can use a better content type for the programs.

You will need the "Update metadata in the background" setting enabled for this.

Fixes #120 