### PR TITLE
Use new EPG API

### DIFF
--- a/resources/lib/modules/player.py
+++ b/resources/lib/modules/player.py
@@ -19,6 +19,23 @@ class Player:
         self._vtm_go = VtmGo(self._kodi)
         self._vtm_go_stream = VtmGoStream(self._kodi)
 
+    def play_or_live(self, category, item, channel):
+        """ Ask to play the requested item or switch to the live channel
+        :type category: str
+        :type item: str
+        :type channel: str
+        """
+        res = self._kodi.show_context_menu([self._kodi.localize(30103), self._kodi.localize(30105)])  # Watch Live | Play from Catalog
+        if res == -1:  # user has cancelled
+            return
+        if res == 0:  # user selected "Watch Live"
+            # Play live
+            self.play('channels', channel)
+            return
+
+        # Play this program
+        self.play(category, item)
+
     def play(self, category, item):
         """ Play the requested item.
         :type category: string
@@ -42,12 +59,10 @@ class Player:
 
         except StreamGeoblockedException:
             self._kodi.show_ok_dialog(heading=self._kodi.localize(30709), message=self._kodi.localize(30710))  # This video is geo-blocked...
-            self._kodi.end_of_directory()
             return
 
         except StreamUnavailableException:
             self._kodi.show_ok_dialog(heading=self._kodi.localize(30711), message=self._kodi.localize(30712))  # The video is unavailable...
-            self._kodi.end_of_directory()
             return
 
         info_dict = {

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -75,13 +75,6 @@ def show_tvguide_detail(channel=None, date=None):
     TvGuide(kodi).show_tvguide_detail(channel, date)
 
 
-@routing.route('/tvguide/program/<channel>/<program>')
-def show_program_from_epg(channel, program):
-    """ Show a program based on the channel and information from the EPG """
-    from resources.lib.modules.tvguide import TvGuide
-    TvGuide(kodi).show_program_from_epg(channel, program)
-
-
 @routing.route('/catalog')
 def show_catalog():
     """ Show the catalog """
@@ -195,12 +188,11 @@ def play_epg_datetime(channel, timestamp):
     TvGuide(kodi).play_epg_datetime(channel, timestamp)
 
 
-@routing.route('/play/epg/<channel>/<program_type>/<epg_id>')
-@routing.route('/play/epg/<channel>/<program_type>/<epg_id>/<airing>')
-def play_epg_program(channel, program_type, epg_id, airing=None):
-    """ Play a program based on the channel and information from the EPG """
-    from resources.lib.modules.tvguide import TvGuide
-    TvGuide(kodi).play_epg_program(channel, program_type, epg_id, airing)
+@routing.route('/play/catalog/<category>/<item>/<channel>')
+def play_or_live(category, item, channel):
+    """ Ask to play the requested item or switch to the live channel """
+    from resources.lib.modules.player import Player
+    Player(kodi).play_or_live(category, item, channel)
 
 
 @routing.route('/play/catalog/<category>/<item>')

--- a/resources/lib/vtmgo/vtmgo.py
+++ b/resources/lib/vtmgo/vtmgo.py
@@ -7,7 +7,7 @@ import json
 
 import requests
 
-from resources.lib.kodiwrapper import LOG_DEBUG, LOG_INFO
+from resources.lib.kodiwrapper import LOG_DEBUG
 from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
 
 try:  # Python 3
@@ -753,7 +753,7 @@ class VtmGo:
         if profile:
             headers['x-dpp-profile'] = profile
 
-        self._kodi.log('Sending GET {url}...', LOG_INFO, url=url)
+        self._kodi.log('Sending GET {url}...', url=url)
 
         response = requests.session().get('https://lfvp-api.dpgmedia.net' + url, params=params, headers=headers, proxies=self._proxies)
 
@@ -781,7 +781,7 @@ class VtmGo:
         if profile:
             headers['x-dpp-profile'] = profile
 
-        self._kodi.log('Sending PUT {url}...', LOG_INFO, url=url)
+        self._kodi.log('Sending PUT {url}...', url=url)
 
         response = requests.session().put('https://api.vtmgo.be' + url, headers=headers, proxies=self._proxies)
 
@@ -809,7 +809,7 @@ class VtmGo:
         if profile:
             headers['x-dpp-profile'] = profile
 
-        self._kodi.log('Sending POST {url}...', LOG_INFO, url=url)
+        self._kodi.log('Sending POST {url}...', url=url)
 
         response = requests.session().post('https://api.vtmgo.be' + url, headers=headers, proxies=self._proxies)
 
@@ -837,7 +837,7 @@ class VtmGo:
         if profile:
             headers['x-dpp-profile'] = profile
 
-        self._kodi.log('Sending DELETE {url}...', LOG_INFO, url=url)
+        self._kodi.log('Sending DELETE {url}...', url=url)
 
         response = requests.session().delete('https://api.vtmgo.be' + url, headers=headers, proxies=self._proxies)
 

--- a/test/test_vtmgoepg.py
+++ b/test/test_vtmgoepg.py
@@ -62,23 +62,11 @@ class TestVtmGoEpg(unittest.TestCase):
 
         broadcast = next(b for b in combined_broadcasts if b.playable_type == 'episodes')
         if broadcast:
-            details = self._vtmgoepg.get_details(channel='vtm', program_type=broadcast.playable_type, epg_id=broadcast.uuid)
-            self.assertTrue(details)
-            plugin.run([routing.url_for(plugin.show_program_from_epg, channel='vtm', program=broadcast.uuid), '0', ''])
+            plugin.run([routing.url_for(plugin.show_catalog_program, program=broadcast.program_uuid), '0', ''])
 
         broadcast = next(b for b in combined_broadcasts if b.playable_type == 'movies')
         if broadcast:
-            details = self._vtmgoepg.get_details(channel='vtm', program_type=broadcast.playable_type, epg_id=broadcast.uuid)
-            self.assertTrue(details)
-            plugin.run(
-                [routing.url_for(plugin.play_epg_program, channel='vtm', program_type=broadcast.playable_type, epg_id=broadcast.uuid, aired='123'), '0', ''])
-
-        broadcast = next(b for b in combined_broadcasts if b.playable_type == 'oneoffs')
-        if broadcast:
-            details = self._vtmgoepg.get_details(channel='vtm', program_type=broadcast.playable_type, epg_id=broadcast.uuid)
-            self.assertTrue(details)
-
-        plugin.run([routing.url_for(plugin.show_program_from_epg, channel='vtm', program='error'), '0', ''])
+            plugin.run([routing.url_for(plugin.play, category=broadcast.playable_type, item=broadcast.playable_uuid), '0', ''])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It seems the EPG API used on vtm.be is updated since last time I checked, and now contains the `playable_uuid` directly in the overview. This allows us to directly play items from the EPG listing, without scraping the HTML for the `playable_uuid`.

Updated documentation is at https://github.com/michaelarnauts/plugin.video.vtm.go/wiki/API%3A-EPG